### PR TITLE
Fix missing distinctID

### DIFF
--- a/src/engines/Engine.php
+++ b/src/engines/Engine.php
@@ -35,12 +35,13 @@ abstract class Engine
             $splittedObjects = $this->splitObject($object);
 
             if (count($splittedObjects) <= 1) {
-                $object['distinctID'] = $object['objectID'];
-
                 if (Scout::$plugin->getSettings()->useOriginalRecordIfSplitValueIsArrayOfOne) {
+                    $object['distinctID'] = $object['objectID'];
                     $objectsToSave[] = $object;
                 } else {
-                    $objectsToSave[] = count($splittedObjects) === 1 ? $splittedObjects[0] : $object;
+                    $objectToSave = $splittedObjects[0] ?? $object;
+                    $objectToSave['distinctID'] = $objectToSave['objectID'];
+                    $objectsToSave[] = $objectToSave;
                 }
 
                 continue;


### PR DESCRIPTION
🤦 If we use the split object, we need to manually set `distinctID`. If you expand the diff to see rows lower down, you can see this is exactly how it's handled in the case of multiple split objects.