### PR TITLE
Make related elements configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.7.3 - 2022-06-21 (Viget)
+
+### Added
+- Added `relatedElementTypes` option to configure what Element types to query when indexing relations.
+
 ## 2.7.2 - 2022-03-22
 ## Added
 - Added `renderingContent` to `IndexSettings` ([#230](https://github.com/studioespresso/craft-scout/issues/230) & [#231](https://github.com/studioespresso/craft-scout/pull/231) - thanks [@joshuabaker](https://github.com/joshuabaker))
 
 ## 2.7.1 - 2022-03-21
 ### Added
-- ``scout/index/import`` now optionally takes a ``--queue=1`` parameter to run the import(s) through the queue instead running them straigt away. 
+- ``scout/index/import`` now optionally takes a ``--queue=1`` parameter to run the import(s) through the queue instead running them straigt away.
 
 
 ## 2.7.0 - 2022-03-13
 ### Added
-- Added a config setting to keep using the orginal object in case ``splittedObjects`` only contains 1 item. ([#193](https://github.com/studioespresso/craft-scout/issues/193) & [#219](https://github.com/studioespresso/craft-scout/pull/219), thanks [@gregkohn](https://github.com/gregkohn)) 
+- Added a config setting to keep using the orginal object in case ``splittedObjects`` only contains 1 item. ([#193](https://github.com/studioespresso/craft-scout/issues/193) & [#219](https://github.com/studioespresso/craft-scout/pull/219), thanks [@gregkohn](https://github.com/gregkohn))
 
 ## 2.6.1 - 2021-12-21
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "studioespresso/craft-scout",
     "description": "Craft Scout provides a simple solution for adding full-text search to your entries. Scout will automatically keep your search indexes in sync with your entries.",
     "type": "craft-plugin",
-    "version": "2.7.2",
+    "version": "2.7.3",
     "keywords": [
         "craft",
         "cms",

--- a/config/scout.php
+++ b/config/scout.php
@@ -83,4 +83,10 @@ return [
      * Make this false to use the single item itself.
      */
     'useOriginalRecordIfSplitValueIsArrayOfOne' => true,
+
+    /**
+     * The element types to look for when indexRelations is enabled.
+     * By default, all Craft elements are checked for relations.
+     */
+    'relatedElementTypes' => [],
 ];

--- a/src/behaviors/SearchableBehavior.php
+++ b/src/behaviors/SearchableBehavior.php
@@ -131,8 +131,17 @@ class SearchableBehavior extends Behavior
 
     public function getRelatedElements(): Collection
     {
-        if (!Scout::$plugin->getSettings()->sync) {
+        $settings = Scout::$plugin->getSettings();
+
+        if (!$settings->sync) {
             return new Collection();
+        }
+
+        if (!empty($settings->relatedElementTypes)) {
+            return (new Collection($settings->relatedElementTypes))
+                ->flatMap(function($className) {
+                    return $className::find()->relatedTo($this->owner)->site('*')->all();
+                });
         }
 
         $assets = Asset::find()->relatedTo($this->owner)->site('*')->all();

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -54,6 +54,9 @@ class Settings extends Model
     /** @var bool */
     public $useOriginalRecordIfSplitValueIsArrayOfOne = true;
 
+    /** @var array */
+    public $relatedElementTypes = [];
+
     public function fields()
     {
         $fields = parent::fields();


### PR DESCRIPTION
`SearchableBehavior::getRelatedElements()` was hitting memory limit issues on MW. 

This adds configuration to limit what element types are queried. 